### PR TITLE
fix: instruct sequential Write/Bash tool usage to prevent race condition (#27)

### DIFF
--- a/skills/playwright-py-skill/SKILL.md
+++ b/skills/playwright-py-skill/SKILL.md
@@ -12,6 +12,24 @@ Common installation paths:
 - Manual global: `~/.claude/skills/playwright-py-skill`
 - Project-specific: `<project>/.claude/skills/playwright-py-skill`
 
+## CRITICAL: Sequential Tool Usage
+
+When writing and executing Playwright scripts, ALWAYS use Write and Bash tools in separate responses:
+
+❌ **DO NOT use parallel execution (causes race condition):**
+```
+Write: create /tmp/playwright-test.py
+Bash: uv run run.py /tmp/playwright-test.py  <-- Executes before Write completes!
+```
+
+✅ **ALWAYS use sequential execution:**
+```
+Response 1: Write /tmp/playwright-test.py
+Response 2: Bash: cd $SKILL_DIR && uv run run.py /tmp/playwright-test.py
+```
+
+This prevents race conditions where Bash executes before the file is fully written.
+
 # Playwright Browser Automation
 
 General-purpose browser automation skill. I'll write custom Playwright code for any automation task you request and execute it via the universal executor.

--- a/skills/playwright-py-skill/run.py
+++ b/skills/playwright-py-skill/run.py
@@ -51,7 +51,17 @@ def get_code_to_execute():
         print(f"📄 Executing file: {file_path}")
         return file_path.read_text()
 
-    # Case 2: Inline code provided as argument
+    # Case 2: File path-like argument but file doesn't exist (likely race condition)
+    if args and (".py" in args[0] or "/" in args[0] or "\\" in args[0]):
+        print(f"❌ File not found: {args[0]}", file=sys.stderr)
+        print(
+            "⏱️  This may be a race condition - the file may still be being written.",
+            file=sys.stderr,
+        )
+        print("💡 Try running the command again or wait a moment.", file=sys.stderr)
+        sys.exit(1)
+
+    # Case 3: Inline code provided as argument
     if args:
         print("⚡ Executing inline code")
         return " ".join(args)


### PR DESCRIPTION
## Summary

Fixes #27 - Race condition when Write and Bash execute in parallel causes file-not-found errors.

### Problem

When OpenCode executes multiple tools in parallel (default behavior), the following workflow fails:
1. Write tool creates a script file (e.g., `/tmp/playwright-test.py`)
2. Bash tool immediately executes the script via `uv run run.py /tmp/playwright-test.py`
3. Bash executes **before** Write completes, causing file-not-found errors
4. `run.py` treats the missing file path as inline code, resulting in syntax errors

### Solution

This fix addresses the issue by:

1. **Adding prominent instruction in SKILL.md** to use Write and Bash tools in separate responses (sequentially), not in parallel
2. **Including existing detection logic in run.py** that provides helpful error messages when file paths don't exist (indicating a race condition)

### Changes

- **SKILL.md**: Added new "CRITICAL: Sequential Tool Usage" section at the top of the skill documentation with clear examples of correct vs. incorrect usage
- **run.py**: Included uncommitted detection code that identifies file-path-like arguments that don't exist and provides a helpful error message

### User Impact

Users should now use Write and Bash in separate responses instead of parallel execution:

❌ **Parallel (causes race condition):**
```
Write: create /tmp/script.py
Bash: uv run run.py /tmp/script.py
```

✅ **Sequential (reliable):**
```
Response 1: Write /tmp/script.py
Response 2: Bash: cd $SKILL_DIR && uv run run.py /tmp/script.py
```

### Testing

Manual testing with the new instructions confirms sequential tool execution works reliably without race conditions.