### PR TITLE
feat: Add test for Test a Page (Multiple Viewports) example

### DIFF
--- a/tests/test_multiple_viewports.py
+++ b/tests/test_multiple_viewports.py
@@ -72,14 +72,13 @@ class TestMultipleViewports:
                 lines[i] = "    " + dedent(
                     """\
                     page = browser.new_page()
-                    import os
-                    desktop_path = '/tmp/desktop.png'
-                    mobile_path = '/tmp/mobile.png'
+                    desktop_path = Path('/tmp/desktop.png')
+                    mobile_path = Path('/tmp/mobile.png')
 
                     # Clean up any existing screenshots
                     for path in [desktop_path, mobile_path]:
-                        if os.path.exists(path):
-                            os.remove(path)"""
+                        if path.exists():
+                            path.unlink()"""
                 ).replace("\n", "\n    ")
                 modified = True
 
@@ -91,7 +90,7 @@ class TestMultipleViewports:
                     # Test assertions for desktop
                     assert page.viewport_size["width"] == 1920
                     assert page.viewport_size["height"] == 1080
-                    assert os.path.exists(desktop_path)
+                    assert desktop_path.exists()
                     desktop_title = page.title()
                     assert desktop_title is not None
                     assert len(desktop_title) > 0"""
@@ -106,7 +105,7 @@ class TestMultipleViewports:
                     # Test assertions for mobile
                     assert page.viewport_size["width"] == 375
                     assert page.viewport_size["height"] == 667
-                    assert os.path.exists(mobile_path)
+                    assert mobile_path.exists()
                     # Verify title still works after viewport change
                     mobile_title = page.title()
                     assert mobile_title is not None
@@ -120,5 +119,9 @@ class TestMultipleViewports:
         modified_code = "\n".join(lines)
         exec(
             modified_code,
-            {"sync_playwright": sync_playwright, "test_server_url": test_server_url},
+            {
+                "sync_playwright": sync_playwright,
+                "test_server_url": test_server_url,
+                "Path": Path,
+            },
         )


### PR DESCRIPTION
## Summary

Adds a test for the "Test a Page (Multiple Viewports)" example from SKILL.md (lines 118-148).

## Changes

- Created `tests/test_multiple_viewports.py` with `TestMultipleViewports` class
- Test extracts code from SKILL.md at runtime using regex pattern matching
- Test verifies all acceptance criteria:
  - Code is extracted from SKILL.md at runtime
  - Desktop viewport (1920x1080) is set and verified
  - Mobile viewport (375x667) is set and verified
  - Screenshots are taken at each viewport and files exist
  - Page title is retrieved and verified
- Test runs with `headless=True` for CI compatibility
- Uses test server instead of hardcoded localhost URL
- Follows the same pattern as existing tests (`test_basic_browser_automation.py`, `test_test_structure.py`)

## Issue

Fixes #21

## Testing

All tests pass (34 passed in 21.60s)