### PR TITLE
Refactor: Extract duplicate extract_*_code() functions into shared utility

### DIFF
--- a/tests/test_basic_browser_automation.py
+++ b/tests/test_basic_browser_automation.py
@@ -1,9 +1,8 @@
 """Tests for Basic Browser Automation example from API_REFERENCE.md."""
 
-import re
-from pathlib import Path
 from textwrap import dedent
 from playwright.sync_api import sync_playwright
+from conftest import extract_markdown_code
 
 
 def extract_basic_browser_automation_code(test_server_url=None):
@@ -15,27 +14,16 @@ def extract_basic_browser_automation_code(test_server_url=None):
     Returns:
         Modified code ready for execution with test assertions
     """
-    api_ref_path = (
-        Path(__file__).parent.parent
-        / "skills"
-        / "playwright-py-skill"
-        / "API_REFERENCE.md"
+    extracted_code = extract_markdown_code(
+        "Basic Browser Automation",
+        expected_substrings=[
+            "sync_playwright",
+            "chromium.launch",
+            "new_context",
+            "new_page",
+            "goto",
+        ],
     )
-
-    content = api_ref_path.read_text()
-
-    pattern = r"### Basic Browser Automation\s*```python\s*(.*?)```"
-    match = re.search(pattern, content, re.DOTALL)
-
-    assert match, "Basic Browser Automation example not found in API_REFERENCE.md"
-    extracted_code = match.group(1)
-
-    # Verify we extracted the expected code
-    assert "sync_playwright" in extracted_code
-    assert "chromium.launch" in extracted_code
-    assert "new_context" in extracted_code
-    assert "new_page" in extracted_code
-    assert "goto" in extracted_code
 
     # Modify the extracted code for testing:
     # 1. Replace headless=False with headless=True for CI

--- a/tests/test_keyboard_actions.py
+++ b/tests/test_keyboard_actions.py
@@ -1,8 +1,7 @@
 """Tests for Keyboard Actions examples from API_REFERENCE.md."""
 
-import re
-from pathlib import Path
 from playwright.sync_api import sync_playwright
+from conftest import extract_markdown_code
 
 
 def extract_keyboard_actions_code():
@@ -11,32 +10,19 @@ def extract_keyboard_actions_code():
     Returns:
         Modified code ready for execution
     """
-    api_ref_path = (
-        Path(__file__).parent.parent
-        / "skills"
-        / "playwright-py-skill"
-        / "API_REFERENCE.md"
+    return extract_markdown_code(
+        "Keyboard Actions",
+        expected_substrings=[
+            "page.keyboard.type('Hello World', delay=100)",
+            "page.keyboard.press('Control+A')",
+            "page.keyboard.press('Control+C')",
+            "page.keyboard.press('Control+V')",
+            "page.keyboard.press('Enter')",
+            "page.keyboard.press('Tab')",
+            "page.keyboard.press('Escape')",
+            "page.keyboard.press('ArrowDown')",
+        ],
     )
-
-    content = api_ref_path.read_text()
-
-    pattern = r"### Keyboard Actions\s*```python\s*(.*?)```"
-    match = re.search(pattern, content, re.DOTALL)
-
-    assert match, "Keyboard Actions example not found in API_REFERENCE.md"
-    extracted_code = match.group(1)
-
-    # Verify we extracted the expected code
-    assert "page.keyboard.type('Hello World', delay=100)" in extracted_code
-    assert "page.keyboard.press('Control+A')" in extracted_code
-    assert "page.keyboard.press('Control+C')" in extracted_code
-    assert "page.keyboard.press('Control+V')" in extracted_code
-    assert "page.keyboard.press('Enter')" in extracted_code
-    assert "page.keyboard.press('Tab')" in extracted_code
-    assert "page.keyboard.press('Escape')" in extracted_code
-    assert "page.keyboard.press('ArrowDown')" in extracted_code
-
-    return extracted_code
 
 
 class TestKeyboardActions:

--- a/tests/test_mouse_actions.py
+++ b/tests/test_mouse_actions.py
@@ -1,8 +1,8 @@
 """Tests for Mouse Actions examples from API_REFERENCE.md."""
 
 import re
-from pathlib import Path
 from playwright.sync_api import sync_playwright
+from conftest import extract_markdown_code
 
 
 def extract_mouse_actions_code():
@@ -11,33 +11,20 @@ def extract_mouse_actions_code():
     Returns:
         Modified code ready for execution
     """
-    api_ref_path = (
-        Path(__file__).parent.parent
-        / "skills"
-        / "playwright-py-skill"
-        / "API_REFERENCE.md"
+    return extract_markdown_code(
+        "Mouse Actions",
+        expected_substrings=[
+            "page.click('button')",
+            "page.click('button', button=\"right\")",
+            "page.dblclick('button')",
+            'page.click(\'button\', position={"x": 10, "y": 10})',
+            "page.hover('.menu-item')",
+            "page.drag_and_drop('#source', '#target')",
+            "page.locator('#source').hover()",
+            "page.mouse.down()",
+            "page.mouse.up()",
+        ],
     )
-
-    content = api_ref_path.read_text()
-
-    pattern = r"### Mouse Actions\s*```python\s*(.*?)```"
-    match = re.search(pattern, content, re.DOTALL)
-
-    assert match, "Mouse Actions example not found in API_REFERENCE.md"
-    extracted_code = match.group(1)
-
-    # Verify we extracted the expected code
-    assert "page.click('button')" in extracted_code
-    assert "page.click('button', button=\"right\")" in extracted_code
-    assert "page.dblclick('button')" in extracted_code
-    assert 'page.click(\'button\', position={"x": 10, "y": 10})' in extracted_code
-    assert "page.hover('.menu-item')" in extracted_code
-    assert "page.drag_and_drop('#source', '#target')" in extracted_code
-    assert "page.locator('#source').hover()" in extracted_code
-    assert "page.mouse.down()" in extracted_code
-    assert "page.mouse.up()" in extracted_code
-
-    return extracted_code
 
 
 class TestMouseActions:

--- a/tests/test_multiple_viewports.py
+++ b/tests/test_multiple_viewports.py
@@ -1,9 +1,9 @@
 """Tests for Test a Page (Multiple Viewports) example from SKILL.md."""
 
-import re
 from pathlib import Path
 from textwrap import dedent
 from playwright.sync_api import sync_playwright
+from conftest import extract_markdown_code
 
 
 def extract_multiple_viewports_code():
@@ -12,25 +12,16 @@ def extract_multiple_viewports_code():
     Returns:
         Modified code ready for execution with test assertions
     """
-    skill_path = (
-        Path(__file__).parent.parent / "skills" / "playwright-py-skill" / "SKILL.md"
+    return extract_markdown_code(
+        "Test a Page (Multiple Viewports)",
+        markdown_file="SKILL.md",
+        expected_substrings=[
+            "sync_playwright",
+            "set_viewport_size",
+            "screenshot",
+            "page.title()",
+        ],
     )
-
-    content = skill_path.read_text()
-
-    pattern = r"### Test a Page \(Multiple Viewports\)\s*```python\s*(.*?)```"
-    match = re.search(pattern, content, re.DOTALL)
-
-    assert match, "Test a Page (Multiple Viewports) example not found in SKILL.md"
-    extracted_code = match.group(1)
-
-    # Verify we extracted the expected code
-    assert "sync_playwright" in extracted_code
-    assert "set_viewport_size" in extracted_code
-    assert "screenshot" in extracted_code
-    assert "page.title()" in extracted_code
-
-    return extracted_code
 
 
 class TestMultipleViewports:

--- a/tests/test_selectors_locators.py
+++ b/tests/test_selectors_locators.py
@@ -1,8 +1,9 @@
 """Tests for Selectors & Locators examples from API_REFERENCE.md."""
 
 import re as python_re
-from pathlib import Path
 from playwright.sync_api import sync_playwright
+
+from conftest import extract_markdown_code
 
 
 def extract_selectors_locators_code():
@@ -11,32 +12,8 @@ def extract_selectors_locators_code():
     Returns:
         Tuple of (best_practices_code, advanced_patterns_code)
     """
-    api_ref_path = (
-        Path(__file__).parent.parent
-        / "skills"
-        / "playwright-py-skill"
-        / "API_REFERENCE.md"
-    )
-
-    content = api_ref_path.read_text()
-
-    # Extract Best Practices for Selectors section
-    best_pattern = r"### Best Practices for Selectors\s*```python\s*(.*?)```"
-    best_match = python_re.search(best_pattern, content, python_re.DOTALL)
-
-    assert best_match, (
-        "Best Practices for Selectors example not found in API_REFERENCE.md"
-    )
-    best_practices_code = best_match.group(1)
-
-    # Extract Advanced Locator Patterns section
-    advanced_pattern = r"### Advanced Locator Patterns\s*```python\s*(.*?)```"
-    advanced_match = python_re.search(advanced_pattern, content, python_re.DOTALL)
-
-    assert advanced_match, (
-        "Advanced Locator Patterns example not found in API_REFERENCE.md"
-    )
-    advanced_patterns_code = advanced_match.group(1)
+    best_practices_code = extract_markdown_code("Best Practices for Selectors")
+    advanced_patterns_code = extract_markdown_code("Advanced Locator Patterns")
 
     return best_practices_code, advanced_patterns_code
 

--- a/tests/test_test_structure.py
+++ b/tests/test_test_structure.py
@@ -1,8 +1,7 @@
 """Tests for Test Structure pattern from API_REFERENCE.md."""
 
-import re
-from pathlib import Path
 from playwright.sync_api import sync_playwright, Page, expect
+from conftest import extract_markdown_code
 
 
 def extract_test_structure_code():
@@ -11,29 +10,16 @@ def extract_test_structure_code():
     Returns:
         Modified code ready for execution with test assertions
     """
-    api_ref_path = (
-        Path(__file__).parent.parent
-        / "skills"
-        / "playwright-py-skill"
-        / "API_REFERENCE.md"
+    return extract_markdown_code(
+        "Test Structure",
+        expected_substrings=[
+            "Page",
+            "expect",
+            'data-testid="submit-button"',
+            "to_have_url",
+            "to_have_text",
+        ],
     )
-
-    content = api_ref_path.read_text()
-
-    pattern = r"### Test Structure\s*```python\s*(.*?)```"
-    match = re.search(pattern, content, re.DOTALL)
-
-    assert match, "Test Structure example not found in API_REFERENCE.md"
-    extracted_code = match.group(1)
-
-    # Verify we extracted the expected code
-    assert "Page" in extracted_code
-    assert "expect" in extracted_code
-    assert 'data-testid="submit-button"' in extracted_code
-    assert "to_have_url" in extracted_code
-    assert "to_have_text" in extracted_code
-
-    return extracted_code
 
 
 class TestTestStructure:


### PR DESCRIPTION
## Summary

This PR implements the refactoring requested in issue #38 by extracting the duplicate `extract_*_code()` functions from six test files into a shared utility function.

## Changes

- Added `extract_markdown_code()` utility function to `tests/conftest.py` that:
  - Takes section name, markdown file name, and optional expected substrings
  - Uses `re.escape()` to properly handle special regex characters in section names
  - Performs validation of extracted code against expected substrings
  - Returns the extracted code block

- Refactored all six test files to use the shared utility:
  - `test_basic_browser_automation.py`
  - `test_keyboard_actions.py`
  - `test_mouse_actions.py`
  - `test_selectors_locators.py` (special case: extracts two sections)
  - `test_multiple_viewports.py`
  - `test_test_structure.py`

## Benefits

- **Reduced code duplication**: Eliminated ~140 lines of duplicate code across 6 test files
- **Easier maintenance**: Changes to extraction pattern only need to be made in one place
- **Consistent error messages**: All extractions now use the same error format
- **Clearer intent**: Test code more clearly shows it's using a shared extraction utility

## Testing

All 34 tests pass, including the 7 tests in the refactored files.

Fixes #38