### PR TITLE
Refactor: Extract duplicate action log extraction into helper function

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,19 @@ def extract_markdown_code(
     return extracted_code
 
 
+def get_action_log(page):
+    """Extract and parse action log content from the page.
+
+    Args:
+        page: Playwright Page object
+
+    Returns:
+        List of non-empty, stripped log lines from #action-log element
+    """
+    log_content = page.locator("#action-log").text_content()
+    return [line.strip() for line in log_content.strip().split("\n") if line.strip()]
+
+
 app = Flask(__name__, template_folder="templates", static_folder="static")
 app.secret_key = "test-secret-key"
 

--- a/tests/test_keyboard_actions.py
+++ b/tests/test_keyboard_actions.py
@@ -1,7 +1,7 @@
 """Tests for Keyboard Actions examples from API_REFERENCE.md."""
 
 from playwright.sync_api import sync_playwright
-from conftest import extract_markdown_code
+from conftest import extract_markdown_code, get_action_log
 
 
 def extract_keyboard_actions_code():
@@ -88,10 +88,7 @@ class TestKeyboardActions:
             exec("\n".join(modified_code), {"page": page})
 
             # Get action log and verify
-            log_content = page.locator("#action-log").text_content()
-            log_lines = [
-                line.strip() for line in log_content.strip().split("\n") if line.strip()
-            ]
+            log_lines = get_action_log(page)
 
             # Expected log entries
             # Type with delay should log each character as it's typed

--- a/tests/test_mouse_actions.py
+++ b/tests/test_mouse_actions.py
@@ -2,7 +2,7 @@
 
 import re
 from playwright.sync_api import sync_playwright
-from conftest import extract_markdown_code
+from conftest import extract_markdown_code, get_action_log
 
 
 def extract_mouse_actions_code():
@@ -82,10 +82,7 @@ class TestMouseActions:
             exec("\n".join(modified_code), {"page": page})
 
             # Get action log and verify
-            log_content = page.locator("#action-log").text_content()
-            log_lines = [
-                line.strip() for line in log_content.strip().split("\n") if line.strip()
-            ]
+            log_lines = get_action_log(page)
 
             # Expected log entries
             # Note: The actual coordinate values may vary slightly, but position=10,10 should be close

--- a/tests/test_selectors_locators.py
+++ b/tests/test_selectors_locators.py
@@ -3,7 +3,7 @@
 import re as python_re
 from playwright.sync_api import sync_playwright
 
-from conftest import extract_markdown_code
+from conftest import extract_markdown_code, get_action_log
 
 
 def extract_selectors_locators_code():
@@ -55,10 +55,7 @@ class TestSelectorsAndLocators:
             exec(modified_advanced_code, {"page": page, "re": python_re})
 
             # Get action log and verify
-            log_content = page.locator("#action-log").text_content()
-            log_lines = [
-                line.strip() for line in log_content.strip().split("\n") if line.strip()
-            ]
+            log_lines = get_action_log(page)
 
             # Expected log entries
             expected_log = [


### PR DESCRIPTION
## Summary
- Creates `get_action_log(page)` helper function in `tests/conftest.py` to extract and parse action log content
- Replaces duplicate 4-line code blocks in three test files with a single function call
- Reduces code duplication and improves maintainability

## Changes
- **tests/conftest.py**: Added `get_action_log(page)` helper function
- **tests/test_keyboard_actions.py**: Replaced duplicate code with `get_action_log(page)`
- **tests/test_mouse_actions.py**: Replaced duplicate code with `get_action_log(page)`
- **tests/test_selectors_locators.py**: Replaced duplicate code with `get_action_log(page)`

## Benefits
- Reduces 4 lines of duplicate code per test method
- Clearer intent with descriptive function name
- Single place to update if log format changes
- Consistent parsing behavior across all tests

Fixes #39