### PR TITLE
fix: #40 - Extract duplicate JSON extraction into helper function

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,25 @@ def get_action_log(page):
     return [line.strip() for line in log_content.strip().split("\n") if line.strip()]
 
 
+def extract_json_from_page(page):
+    """Extract JSON from page content, handling Flask-wrapped <pre> tags.
+
+    Args:
+        page: Playwright Page object
+
+    Returns:
+        Parsed JSON data from the page content
+    """
+    import json
+
+    page_content = page.content()
+    json_match = re.search(r"<pre>(.*?)</pre>", page_content, re.DOTALL)
+    if json_match:
+        return json.loads(json_match.group(1))
+    else:
+        return json.loads(page_content)
+
+
 app = Flask(__name__, template_folder="templates", static_folder="static")
 app.secret_key = "test-secret-key"
 

--- a/tests/test_custom_headers.py
+++ b/tests/test_custom_headers.py
@@ -1,7 +1,6 @@
 """ "Tests for Custom HTTP Headers feature via environment variables."""
 
 import sys
-import re
 import json
 from pathlib import Path
 from playwright.sync_api import sync_playwright
@@ -17,6 +16,7 @@ from lib.helpers import (
     get_context_options_with_headers,
     create_context,
 )
+from conftest import extract_json_from_page
 
 
 class TestGetExtraHeadersFromEnv:
@@ -229,15 +229,7 @@ class TestHeadersInHttpRequests:
             page.goto(f"{test_server_url}/headers")
             page.wait_for_load_state("networkidle")
 
-            # Extract JSON from <pre> tag (Flask dev server wraps JSON response)
-            page_content = page.content()
-
-            json_match = re.search(r"<pre>(.*?)</pre>", page_content, re.DOTALL)
-            if json_match:
-                response = json.loads(json_match.group(1))
-            else:
-                # Fallback: try parsing entire content
-                response = json.loads(page_content)
+            response = extract_json_from_page(page)
 
             # Check that our custom header was sent
             # The /headers endpoint returns request headers as JSON
@@ -266,14 +258,7 @@ class TestHeadersInHttpRequests:
             page.goto(f"{test_server_url}/headers")
             page.wait_for_load_state("networkidle")
 
-            # Extract JSON from <pre> tag (Flask dev server wraps JSON response)
-            page_content = page.content()
-
-            json_match = re.search(r"<pre>(.*?)</pre>", page_content, re.DOTALL)
-            if json_match:
-                response = json.loads(json_match.group(1))
-            else:
-                response = json.loads(page_content)
+            response = extract_json_from_page(page)
 
             # Check that all custom headers were sent
             assert "X-Automated-By" in response
@@ -302,14 +287,7 @@ class TestHeadersInHttpRequests:
                 page.goto(f"{test_server_url}/headers")
                 page.wait_for_load_state("networkidle")
 
-                # Extract JSON from <pre> tag (Flask dev server wraps JSON response)
-                page_content = page.content()
-
-                json_match = re.search(r"<pre>(.*?)</pre>", page_content, re.DOTALL)
-                if json_match:
-                    response = json.loads(json_match.group(1))
-                else:
-                    response = json.loads(page_content)
+                response = extract_json_from_page(page)
 
                 # Check that header is present on each request
                 assert "X-Request-Tracker" in response


### PR DESCRIPTION
## Summary

- Added `extract_json_from_page()` helper function to `tests/conftest.py` that handles both Flask-wrapped (in `<pre>` tags) and direct JSON response cases
- Replaced duplicate JSON extraction code in three test methods with calls to the new helper function
- Removed unnecessary `re` import from `tests/test_custom_headers.py`

## Changes

- **`tests/conftest.py`**: Added new `extract_json_from_page(page)` helper function
- **`tests/test_custom_headers.py`**: 
  - Replaced duplicate JSON extraction blocks in `test_single_header_sent_in_request`, `test_multiple_headers_sent_in_request`, and `test_headers_sent_on_all_requests`
  - Removed unused `re` import

## Benefits

- Eliminates ~27 lines of duplicate code (9 lines × 3 methods)
- Single source of truth for JSON extraction logic
- Easier to maintain if response format changes

Closes #40